### PR TITLE
Bump/4.9.2

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.9.1-php7.2-apache
+FROM wordpress:4.9.2-php7.2-apache
 
 RUN deps="wget unzip" && apt-get update \
  && apt-get --no-install-recommends -y install $deps \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.9.1-php7.2-fpm-alpine
+FROM wordpress:4.9.2-php7.2-fpm-alpine
 
 RUN apk add --no-cache --virtual .deps wget unzip \
  && mkdir /tmp/wp-plugins && cd /tmp/wp-plugins \


### PR DESCRIPTION
* apache
    * base:  wordpress:4.9.2-php7.2-apache
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.4
        * amazon-s3-and-cloudfront: 1.2.1
        * ga-google-analytics: 20171103
    * fixes: multi language support bug
* fpm-alpine
    * base: wordpress:4.9.2-php7.2-fpm-alpine
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.4
        * amazon-s3-and-cloudfront: 1.2.1
        * ga-google-analytics: 20171103
    * fixes: multi language support bug