### PR TITLE
Bump/4.9.4

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.9.2-php7.2-apache
+FROM wordpress:4.9.4-php7.2-apache
 
 RUN deps="wget unzip" && apt-get update \
  && apt-get --no-install-recommends -y install $deps \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -4,8 +4,8 @@ RUN deps="wget unzip" && apt-get update \
  && apt-get --no-install-recommends -y install $deps \
  && mkdir /tmp/wp-plugins && cd /tmp/wp-plugins \
  && wget https://downloads.wordpress.org/plugin/simply-static.2.1.0.zip \
- && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.4.zip \
- && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.2.1.zip \
+ && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.5.zip \
+ && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.3.2.zip \
  && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20171103.zip \
  && unzip './*.zip' -d /usr/src/wordpress/wp-content/plugins \
  && chown -R www-data:www-data /usr/src/wordpress/wp-content \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.9.2-php7.2-fpm-alpine
+FROM wordpress:4.9.4-php7.2-fpm-alpine
 
 RUN apk add --no-cache --virtual .deps wget unzip \
  && mkdir /tmp/wp-plugins && cd /tmp/wp-plugins \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -3,8 +3,8 @@ FROM wordpress:4.9.4-php7.2-fpm-alpine
 RUN apk add --no-cache --virtual .deps wget unzip \
  && mkdir /tmp/wp-plugins && cd /tmp/wp-plugins \
  && wget https://downloads.wordpress.org/plugin/simply-static.2.1.0.zip \
- && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.4.zip \
- && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.2.1.zip \
+ && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.5.zip \
+ && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.3.2.zip \
  && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20171103.zip \
  && unzip './*.zip' -d /usr/src/wordpress/wp-content/plugins \
  && chown -R www-data:www-data /usr/src/wordpress/wp-content \


### PR DESCRIPTION
* apache
    * base:  wordpress:4.9.4-php7.2-apache
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.5
        * amazon-s3-and-cloudfront: 1.3.2
        * ga-google-analytics: 20171103
    * fixes: multi language support bug
* fpm-alpine
    * base: wordpress:4.9.4-php7.2-fpm-alpine
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.5
        * amazon-s3-and-cloudfront: 1.3.2
        * ga-google-analytics: 20171103
    * fixes: multi language support bug