### PR TITLE
Bump/ga.20180303

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -6,7 +6,7 @@ RUN deps="wget unzip" && apt-get update \
  && wget https://downloads.wordpress.org/plugin/simply-static.2.1.0.zip \
  && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.5.zip \
  && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.3.2.zip \
- && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20171103.zip \
+ && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20180303.zip \
  && unzip './*.zip' -d /usr/src/wordpress/wp-content/plugins \
  && chown -R www-data:www-data /usr/src/wordpress/wp-content \
  && cd \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache --virtual .deps wget unzip \
  && wget https://downloads.wordpress.org/plugin/simply-static.2.1.0.zip \
  && wget https://downloads.wordpress.org/plugin/amazon-web-services.1.0.5.zip \
  && wget https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.3.2.zip \
- && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20171103.zip \
+ && wget https://downloads.wordpress.org/plugin/ga-google-analytics.20180303.zip \
  && unzip './*.zip' -d /usr/src/wordpress/wp-content/plugins \
  && chown -R www-data:www-data /usr/src/wordpress/wp-content \
  && cd \


### PR DESCRIPTION
* apache
    * base:  wordpress:4.9.4-php7.2-apache
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.5
        * amazon-s3-and-cloudfront: 1.3.2
        * ga-google-analytics: 20180303
    * fixes: multi language support bug
* fpm-alpine
    * base: wordpress:4.9.4-php7.2-fpm-alpine
    * plugins:
        * simply-static: 2.1.0
        * amazon-web-services: 1.0.5
        * amazon-s3-and-cloudfront: 1.3.2
        * ga-google-analytics: 20180303
    * fixes: multi language support bug